### PR TITLE
TESTING: Fix: ensure block style is always loaded on demand for classic themes

### DIFF
--- a/plugins/woocommerce/changelog/fix-58791
+++ b/plugins/woocommerce/changelog/fix-58791
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: ensure block style is always loaded on demand for classic themes.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -240,36 +240,6 @@ abstract class AbstractBlock {
 
 		$metadata_path = $this->asset_api->get_block_metadata_path( $this->block_name );
 
-		/**
-		 * We always want to load block styles separately, for every theme.
-		 * When the core assets are loaded separately, other blocks' styles get
-		 * enqueued separately too. Thus we only need to handle the remaining
-		 * case.
-		 */
-		if (
-			! is_admin() &&
-			! wp_is_block_theme() &&
-			! empty( $block_settings['style'] ) &&
-			(
-				! function_exists( 'wp_should_load_separate_core_block_assets' ) ||
-				! wp_should_load_separate_core_block_assets()
-			)
-		) {
-			$style_handles           = $block_settings['style'];
-			$block_settings['style'] = null;
-			add_filter(
-				'render_block',
-				function ( $html, $block ) use ( $style_handles ) {
-					if ( $block['blockName'] === $this->get_block_type() ) {
-						array_map( 'wp_enqueue_style', $style_handles );
-					}
-					return $html;
-				},
-				10,
-				2
-			);
-		}
-
 		// Prefer to register with metadata if the path is set in the block's class.
 		if ( ! empty( $metadata_path ) ) {
 			register_block_type_from_metadata(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -227,7 +227,30 @@ abstract class AbstractBlock {
 
 		// Conditionally override these, otherwise rely on block.json metadata.
 		if ( $this->get_block_type_style() ) {
-			$block_settings['style'] = $this->get_block_type_style();
+			$style_handles = $this->get_block_type_style();
+			$block_name    = $this->get_block_type();
+			if (
+				is_admin() ||
+				wp_is_block_theme() ||
+				false === strpos( $block_name, 'woocommerce/' ) ||
+				empty( $style_handles ) ||
+				( function_exists( 'wp_should_load_block_assets_on_demand' ) && wp_should_load_block_assets_on_demand() ) ||
+				wp_should_load_separate_core_block_assets()
+			) {
+				$block_settings['style'] = $style_handles;
+			} else {
+				add_filter(
+					'render_block',
+					static function ( $html, $block ) use ( $style_handles, $block_name ) {
+						if ( $block['blockName'] === $block_name ) {
+							array_map( 'wp_enqueue_style', $style_handles );
+						}
+					return $html;
+				},
+				10,
+				2
+			);
+			}
 		}
 
 		if ( $this->get_block_type_editor_style() ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -227,30 +227,7 @@ abstract class AbstractBlock {
 
 		// Conditionally override these, otherwise rely on block.json metadata.
 		if ( $this->get_block_type_style() ) {
-			$style_handles = $this->get_block_type_style();
-			$block_name    = $this->get_block_type();
-			if (
-				is_admin() ||
-				wp_is_block_theme() ||
-				false === strpos( $block_name, 'woocommerce/' ) ||
-				empty( $style_handles ) ||
-				( function_exists( 'wp_should_load_block_assets_on_demand' ) && wp_should_load_block_assets_on_demand() ) ||
-				wp_should_load_separate_core_block_assets()
-			) {
-				$block_settings['style'] = $style_handles;
-			} else {
-				add_filter(
-					'render_block',
-					static function ( $html, $block ) use ( $style_handles, $block_name ) {
-						if ( $block['blockName'] === $block_name ) {
-							array_map( 'wp_enqueue_style', $style_handles );
-						}
-					return $html;
-				},
-				10,
-				2
-			);
-			}
+			$block_settings['style'] = $this->get_block_type_style();
 		}
 
 		if ( $this->get_block_type_editor_style() ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -621,7 +621,7 @@ final class BlockTypesController {
 	 *
 	 * @internal
 	 *
-	 * @param array $args Block metadata.
+	 * @param array  $args Block metadata.
 	 * @param string $block_name Block name.
 	 *
 	 * @return array Block metadata.
@@ -633,7 +633,7 @@ final class BlockTypesController {
 			( function_exists( 'wp_should_load_block_assets_on_demand' ) && wp_should_load_block_assets_on_demand() ) ||
 			wp_should_load_separate_core_block_assets() ||
 			false === strpos( $block_name, 'woocommerce/' ) ||
-			empty( $args['style_handles'] ) && empty( $args['style'] )
+			( empty( $args['style_handles'] ) && empty( $args['style'] ) )
 		) {
 			return $args;
 		}
@@ -653,7 +653,7 @@ final class BlockTypesController {
 		);
 
 		$args['style_handles'] = array();
-		$args['style'] = array();
+		$args['style']         = array();
 
 		return $args;
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -63,6 +63,7 @@ final class BlockTypesController {
 		add_action( 'woocommerce_login_form_end', array( $this, 'redirect_to_field' ) );
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_legacy_widgets_with_block_equivalent' ) );
 		add_action( 'woocommerce_delete_product_transients', array( $this, 'delete_product_transients' ) );
+		add_filter( 'block_type_metadata_settings', array( $this, 'enqueue_block_style_for_classic_themes' ) );
 	}
 
 	/**
@@ -610,5 +611,45 @@ final class BlockTypesController {
 		 * @param array $block_types List of block types.
 		 */
 		return apply_filters( 'woocommerce_get_block_types', $block_types );
+	}
+
+	/**
+	 * By default, when the classic theme is used, block style is always
+	 * enqueued even if the block is not used on the page. We want WooCommerce
+	 * store to always performant so we have to manually enqueue the block style
+	 * on-demand for classic themes.
+	 *
+	 * @internal
+	 *
+	 * @param array $metadata Block metadata.
+	 *
+	 * @return array Block metadata.
+	 */
+	public function enqueue_block_style_for_classic_themes( $metadata ) {
+		if (
+			is_admin() ||
+			wp_is_block_theme() ||
+			false === strpos( $metadata['name'], 'woocommerce/' ) ||
+			empty( $metadata['style_handles'] ) ||
+			( function_exists( 'wp_should_load_block_assets_on_demand' ) && wp_should_load_block_assets_on_demand() ) ||
+			wp_should_load_separate_core_block_assets()
+		) {
+			return $metadata;
+		}
+
+		add_filter(
+			'render_block',
+			static function ( $html, $block ) use ( $metadata ) {
+				if ( $block['blockName'] === $metadata['name'] ) {
+					array_map( 'wp_enqueue_style', $metadata['style_handles'] );
+				}
+				return $html;
+			},
+			10,
+			2
+		);
+
+		$metadata['style_handles'] = array();
+		return $metadata;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -630,9 +630,9 @@ final class BlockTypesController {
 		if (
 			is_admin() ||
 			wp_is_block_theme() ||
-			false === strpos( $block_name, 'woocommerce/' ) ||
 			( function_exists( 'wp_should_load_block_assets_on_demand' ) && wp_should_load_block_assets_on_demand() ) ||
 			wp_should_load_separate_core_block_assets() ||
+			false === strpos( $block_name, 'woocommerce/' ) ||
 			empty( $args['style_handles'] ) && empty( $args['style'] )
 		) {
 			return $args;

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -63,7 +63,7 @@ final class BlockTypesController {
 		add_action( 'woocommerce_login_form_end', array( $this, 'redirect_to_field' ) );
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_legacy_widgets_with_block_equivalent' ) );
 		add_action( 'woocommerce_delete_product_transients', array( $this, 'delete_product_transients' ) );
-		add_filter( 'block_type_metadata_settings', array( $this, 'enqueue_block_style_for_classic_themes' ) );
+		add_filter( 'register_block_type_args', array( $this, 'enqueue_block_style_for_classic_themes' ), 10, 2 );
 	}
 
 	/**
@@ -621,27 +621,30 @@ final class BlockTypesController {
 	 *
 	 * @internal
 	 *
-	 * @param array $metadata Block metadata.
+	 * @param array $args Block metadata.
+	 * @param string $block_name Block name.
 	 *
 	 * @return array Block metadata.
 	 */
-	public function enqueue_block_style_for_classic_themes( $metadata ) {
+	public function enqueue_block_style_for_classic_themes( $args, $block_name ) {
 		if (
 			is_admin() ||
 			wp_is_block_theme() ||
-			false === strpos( $metadata['name'], 'woocommerce/' ) ||
-			empty( $metadata['style_handles'] ) ||
+			false === strpos( $block_name, 'woocommerce/' ) ||
 			( function_exists( 'wp_should_load_block_assets_on_demand' ) && wp_should_load_block_assets_on_demand() ) ||
-			wp_should_load_separate_core_block_assets()
+			wp_should_load_separate_core_block_assets() ||
+			empty( $args['style_handles'] ) && empty( $args['style'] )
 		) {
-			return $metadata;
+			return $args;
 		}
+
+		$style_handlers = $args['style_handles'] ?? $args['style'];
 
 		add_filter(
 			'render_block',
-			static function ( $html, $block ) use ( $metadata ) {
-				if ( $block['blockName'] === $metadata['name'] ) {
-					array_map( 'wp_enqueue_style', $metadata['style_handles'] );
+			static function ( $html, $block ) use ( $style_handlers, $block_name ) {
+				if ( $block['blockName'] === $block_name ) {
+					array_map( 'wp_enqueue_style', $style_handlers );
 				}
 				return $html;
 			},
@@ -649,7 +652,9 @@ final class BlockTypesController {
 			2
 		);
 
-		$metadata['style_handles'] = array();
-		return $metadata;
+		$args['style_handles'] = array();
+		$args['style'] = array();
+
+		return $args;
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #58791.

Follow up https://github.com/woocommerce/woocommerce-blocks/pull/10758/, this PR expanding the style loading handler for classic themes to support interactive blocks that define style in the metadata file.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Activate a classic theme like Storefront.
2. Visit the page without any WooCommerce blocks, verify that no unused block style is loaded.
3. Visit page with WooCommerce blocks, verify blocks work as before and only style of rendered block is loaded.

<!-- End testing instructions -->