### PR TITLE
TESTING: Move product button add to cart text strings from state to context 

### DIFF
--- a/plugins/woocommerce/changelog/issues-59032-product-button-state-to-context
+++ b/plugins/woocommerce/changelog/issues-59032-product-button-state-to-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Move product button add to cart strings from interactivity state to context

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -23,6 +23,7 @@ interface Context {
 	tempQuantity: number;
 	animationStatus: AnimationStatus;
 	hasPressedButton: boolean;
+	inTheCartText: string;
 }
 
 enum AnimationStatus {
@@ -75,6 +76,7 @@ const productButtonStore = {
 				productType,
 				groupedProductIds,
 				hasPressedButton,
+				inTheCartText,
 			} = getContext< Context >();
 
 			// We use the temporary quantity when there's no animation, or
@@ -99,13 +101,13 @@ const productButtonStore = {
 					groupedProductIdsInCart?.some( ( qty ) => qty > 0 ) &&
 					hasPressedButton
 				) {
-					return state.inTheCartText;
+					return inTheCartText;
 				}
 				return addToCartText;
 			}
 
 			if ( quantity > 0 ) {
-				return state.inTheCartText.replace(
+				return inTheCartText.replace(
 					'###',
 					quantity.toString()
 				);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -98,26 +98,6 @@ class ProductButton extends AbstractBlock {
 
 		$this->register_cart_interactivity( 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce' );
 
-		wp_interactivity_state(
-			'woocommerce/product-button',
-			array(
-				'addToCartText'    => function () use ( $product ) {
-					$context = wp_interactivity_get_context();
-					$quantity = $context['tempQuantity'];
-					$add_to_cart_text = $context['addToCartText'];
-
-					return $quantity > 0 ? sprintf(
-						/* translators: %s: product number. */
-						__( '%s in cart', 'woocommerce' ),
-						$quantity
-					) : $add_to_cart_text;
-				},
-				'inTheCartText'    => $this->get_in_the_cart_text( $product ),
-				'noticeId'         => '',
-				'hasPressedButton' => false,
-			)
-		);
-
 		$number_of_items_in_cart  = $this->get_cart_item_quantities_by_product_id( $product->get_id() );
 		$is_product_purchasable   = $this->is_product_purchasable( $product );
 		$cart_redirect_after_add  = get_option( 'woocommerce_cart_redirect_after_add' ) === 'yes';
@@ -166,9 +146,18 @@ class ProductButton extends AbstractBlock {
 			'quantityToAdd'   => $default_quantity,
 			'productId'       => $product->get_id(),
 			'productType'     => $product->get_type(),
-			'addToCartText'   => $add_to_cart_text,
+			'addToCartText'    => $number_of_items_in_cart > 0
+				? sprintf(
+					/* translators: %s: product quantity. */
+					__( '%s in cart', 'woocommerce' ),
+					$number_of_items_in_cart
+				)
+				: $add_to_cart_text,
 			'tempQuantity'    => $number_of_items_in_cart,
 			'animationStatus' => 'IDLE',
+			'inTheCartText'    => $this->get_in_the_cart_text( $product ),
+			'noticeId'         => '',
+			'hasPressedButton' => false,
 		);
 
 		if ( $product->is_type( 'grouped' ) ) {
@@ -213,9 +202,10 @@ class ProductButton extends AbstractBlock {
 
 		$div_directives = '
 			data-wp-interactive="woocommerce/product-button"
-			data-wp-context=\'' . wp_json_encode( $context, JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ) . '\'
 			data-wp-init="actions.refreshCartItems"
 		';
+
+		$context_directives = wp_interactivity_data_wp_context( $context );
 
 		$button_directives = $is_descendant_of_add_to_cart_form ?
 			'data-wp-class--disabled="woocommerce/add-to-cart-with-options::!state.isFormValid"' :
@@ -264,6 +254,7 @@ class ProductButton extends AbstractBlock {
 			strtr(
 				'<div {wrapper_attributes}
 					{div_directives}
+					{context_directives}
 				>
 					<{html_element}
 						class="{button_classes}"
@@ -279,9 +270,10 @@ class ProductButton extends AbstractBlock {
 					'{wrapper_attributes}'     => $wrapper_attributes,
 					'{html_element}'           => $html_element,
 					'{button_classes}'         => $button_classes,
+					'{context_directives}'     => $context_directives,
 					'{button_styles}'          => esc_attr( $styles_and_classes['styles'] ),
 					'{attributes}'             => isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
-					'{add_to_cart_text}'       => $is_ajax_button ? '' : $add_to_cart_text,
+					'{add_to_cart_text}'       => $add_to_cart_text,
 					'{div_directives}'         => $is_ajax_button ? $div_directives : '',
 					'{button_directives}'      => $is_ajax_button ? $button_directives : $anchor_directive,
 					'{span_button_directives}' => $is_ajax_button ? $span_button_directives : '',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Move product button add to cart text strings from state to context. this improves compatibility with multiple buttons on a single page. 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #59032.
### Screenshots or screen recordings:

before:
![image](https://github.com/user-attachments/assets/776f85db-e280-4630-ab3a-6eab87121d8a)

after:
![image](https://github.com/user-attachments/assets/8c194039-ae35-4db8-a971-9a6e1c93413c)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

see https://github.com/woocommerce/woocommerce/issues/59032 for how to reproduce. I was also able to see it with a grouped products single product page and a related products block on the same page.

with this patch the text should always say "added to cart" after a grouped product is added to cart. 

Keep in mind that until #58990 is merged you will automatically add _all_ the grouped products.

<!-- End testing instructions -->