### PR TITLE
TESTING: Refactor: Move draft status into core order statuses

### DIFF
--- a/plugins/woocommerce/changelog/59031-refactor-56767
+++ b/plugins/woocommerce/changelog/59031-refactor-56767
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Refactored draft order status registration to be defined directly in wc_get_order_statuses() instead of using a hook
+

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -109,6 +109,7 @@ function wc_get_order_statuses() {
 		OrderInternalStatus::CANCELLED  => _x( 'Cancelled', 'Order status', 'woocommerce' ),
 		OrderInternalStatus::REFUNDED   => _x( 'Refunded', 'Order status', 'woocommerce' ),
 		OrderInternalStatus::FAILED     => _x( 'Failed', 'Order status', 'woocommerce' ),
+		OrderInternalStatus::DRAFT      => _x( 'Draft', 'Order status', 'woocommerce' ),
 	);
 	return apply_filters( 'wc_order_statuses', $order_statuses );
 }

--- a/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
@@ -39,7 +39,6 @@ class DraftOrders {
 	 * Set all hooks related to adding Checkout Draft order functionality to Woo Core.
 	 */
 	public function init() {
-		add_filter( 'wc_order_statuses', [ $this, 'register_draft_order_status' ] );
 		add_filter( 'woocommerce_register_shop_order_post_statuses', [ $this, 'register_draft_order_post_status' ] );
 		add_filter( 'woocommerce_analytics_excluded_order_statuses', [ $this, 'append_draft_order_post_status' ] );
 		add_filter( 'woocommerce_valid_order_statuses_for_payment', [ $this, 'append_draft_order_post_status' ], 999 );
@@ -81,20 +80,6 @@ class DraftOrders {
 		if ( false === call_user_func( $has_scheduled_action, self::DRAFT_CLEANUP_EVENT_HOOK ) ) {
 			as_schedule_recurring_action( strtotime( 'midnight tonight' ), DAY_IN_SECONDS, self::DRAFT_CLEANUP_EVENT_HOOK );
 		}
-	}
-
-	/**
-	 * Register custom order status for orders created via the API during checkout.
-	 *
-	 * Draft order status is used before payment is attempted, during checkout, when a cart is converted to an order.
-	 *
-	 * @param array $statuses Array of statuses.
-	 * @internal
-	 * @return array
-	 */
-	public function register_draft_order_status( array $statuses ) {
-		$statuses[ self::DB_STATUS ] = _x( 'Draft', 'Order status', 'woocommerce' );
-		return $statuses;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Enums/OrderInternalStatus.php
+++ b/plugins/woocommerce/src/Enums/OrderInternalStatus.php
@@ -57,4 +57,11 @@ final class OrderInternalStatus {
 	 * @var string
 	 */
 	public const FAILED = 'wc-failed';
+
+	/**
+	 * The order is draft.
+	 *
+	 * @var string
+	 */
+	public const DRAFT = 'wc-checkout-draft';
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #56767  .

(For Bug Fixes) Bug introduced in PR # .



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This change only moves the draft order status definition into the core wc_get_order_statuses() function for better clarity and maintainability. I don't know if we need testing it. 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='/plugin-woocommerce' changelog add` and push it into the branch (replace `/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Refactored draft order status registration to be defined directly in wc_get_order_statuses() instead of using a hook
</details>