### PR TITLE
TESTING: Add to Cart + Options block: simplify and fix pills colors

### DIFF
--- a/plugins/woocommerce/changelog/fix-58925-pills-colors
+++ b/plugins/woocommerce/changelog/fix-58925-pills-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing focus outline in Add to Cart + Options variation selector pills

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
@@ -71,10 +71,9 @@ export default function AttributeOptionsEdit(
 	useThemeColors(
 		'add-to-cart-with-options-variation-selector-attribute-options',
 		( { editorBackgroundColor, editorColor } ) => `
-			:where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill--selected) {
-				background-color: ${ editorColor };
-				color: ${ editorBackgroundColor };
-				border-color: ${ editorColor };
+			.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill--selected {
+				--pill-color: ${ editorBackgroundColor };
+				--pill-background-color: ${ editorColor };
 			}
 		`
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/set-styles.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/set-styles.ts
@@ -70,13 +70,9 @@ function setStyles(): void {
 	// We use :where here to reduce specificity so customized colors and theme CSS take priority.
 	style.appendChild(
 		document.createTextNode(
-			`:where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill):has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:checked) {
-				background-color: ${ selectedPillBackgroundColor };
-				color: ${ selectedPillColor };
-				border-color: ${ selectedPillBackgroundColor };
-			}
-			:where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill):has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:checked):hover{
-				background-color: color-mix(in srgb,${ selectedPillBackgroundColor } 85%,transparent)
+			`.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:checked) {
+				--pill-color: ${ selectedPillColor };
+				--pill-background-color: ${ selectedPillBackgroundColor };
 			}`
 		)
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
@@ -8,34 +8,50 @@
 }
 
 .wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill {
+	--pill-color: currentColor;
+	--pill-background-color: transparent;
+	background-color: var(--pill-background-color);
 	border-radius: 2px;
-	border: 1px solid color-mix(in srgb, currentColor 40%, transparent);
+	border: 1px solid color-mix(in srgb, var(--pill-color) 40%, transparent);
+	color: var(--pill-color);
+	cursor: pointer;
 	font-size: 0.8em;
 	padding: 0.25em 0.75em;
-	cursor: pointer;
 	user-select: none;
 
-	&:focus {
-		outline: 1px solid currentColor;
-		outline-offset: 1px;
+	&:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:disabled) {
+		color: color-mix(in srgb, var(--pill-color) 40%, transparent);
+		cursor: not-allowed;
+		text-decoration: line-through;
 	}
 
 	&:hover {
-		background-color: color-mix(
-			in srgb,
-			var(--wp--preset--color--contrast) 10%,
-			transparent
-		);
+		&:not(:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:disabled)) {
+			background-color: color-mix(
+				in srgb,
+				var(--pill-color) 10%,
+				transparent
+			);
+		}
+	
+		&:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:checked) {
+			background-color: color-mix(
+				in srgb,
+				var(--pill-background-color) 85%,
+				transparent
+			);
+		}
 	}
 
-	&:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:focus) {
-		outline: 1px solid currentColor;
+	&:focus-within {
+		outline: 1px solid var(--pill-color);
 		outline-offset: 1px;
-	}
 
-	&:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:disabled) {
-		color: color-mix(in srgb,currentColor 40%,transparent);
-		text-decoration: line-through;
+		&:has(
+			.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:checked
+		) {
+			outline-color: var(--pill-background-color);
+		}
 	}
 
 	// We can't make it display: none, otherwise it's not focusable.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes several improvements to the way we define colors for the _Variation Selector_ pills in the _Add to Cart + Options_. Specifically, it does:

* Removes `:hover` styles from disabled pills (fixes https://github.com/woocommerce/woocommerce/issues/58925).
* Fixes the `:focus` outline not being visible.
* Removes calls to theme CSS variables like `var(--wp--preset--color--contrast)`.
* Uses `:focus-within` instead of `&:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:focus)`, so the code is cleaner.
* Defines `--pill-color` and `--pill-background-color`, so the same CSS can be used for the different states.

### How to test the changes in this Pull Request:

#### Preparation

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.

#### Reproducing the issue

1. If needed, edit the variations of a variable product to make sure there is a specific combination of attributes where one attribute will be disabled.
2. Visit that product in the frontend.
3. Verify when hovering the disabled pill, the background color doesn't change and the cursor becomes `not-allowed`.
4. Verify focusing pills shows an outline around them.
5. In general, do some smoke testing to make sure there are no styling regressions.

https://github.com/user-attachments/assets/4f2a6417-b9a9-4076-a414-a6c2ebc3bdab