### PR TITLE
TESTING: Remove nocache headers from Cart page to enable bfcache (instant back/forward navigations)

### DIFF
--- a/plugins/woocommerce/includes/class-wc-cache-helper.php
+++ b/plugins/woocommerce/includes/class-wc-cache-helper.php
@@ -51,21 +51,11 @@ class WC_Cache_Helper {
 		$set_cache = false;
 
 		/**
-		 * Allow plugins to enable nocache headers. Enabled for Google weblight.
+		 * Allow plugins to enable nocache headers.
 		 *
 		 * @param bool $enable_nocache_headers Flag indicating whether to add nocache headers. Default: false.
 		 */
 		if ( apply_filters( 'woocommerce_enable_nocache_headers', false ) ) {
-			$set_cache = true;
-		}
-
-		/**
-		 * Enabled for Google weblight.
-		 *
-		 * @see https://support.google.com/webmasters/answer/1061943?hl=en
-		 */
-		if ( false !== strpos( $agent, 'googleweblight' ) ) {
-			// no-transform: Opt-out of Google weblight. https://support.google.com/webmasters/answer/6211428?hl=en.
 			$set_cache = true;
 		}
 

--- a/plugins/woocommerce/includes/class-wc-cache-helper.php
+++ b/plugins/woocommerce/includes/class-wc-cache-helper.php
@@ -128,7 +128,7 @@ class WC_Cache_Helper {
 		if ( ! is_blog_installed() ) {
 			return;
 		}
-		$page_ids = array_filter( array( wc_get_page_id( 'cart' ), wc_get_page_id( 'checkout' ), wc_get_page_id( 'myaccount' ) ) );
+		$page_ids = array_filter( array( wc_get_page_id( 'checkout' ), wc_get_page_id( 'myaccount' ) ) );
 
 		if ( is_page( $page_ids ) ) {
 			self::set_nocache_constants();

--- a/plugins/woocommerce/includes/class-wc-cache-helper.php
+++ b/plugins/woocommerce/includes/class-wc-cache-helper.php
@@ -44,24 +44,12 @@ class WC_Cache_Helper {
 	 * @since 3.6.0
 	 */
 	public static function additional_nocache_headers( $headers ) {
-		global $wp_query;
-
-		$agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-
-		$set_cache = false;
-
 		/**
 		 * Allow plugins to enable nocache headers.
 		 *
 		 * @param bool $enable_nocache_headers Flag indicating whether to add nocache headers. Default: false.
 		 */
-		if ( apply_filters( 'woocommerce_enable_nocache_headers', false ) ) {
-			$set_cache = true;
-		}
-
-		if ( false !== strpos( $agent, 'Chrome' ) && isset( $wp_query ) && is_cart() ) {
-			$set_cache = true;
-		}
+		$set_cache = (bool) apply_filters( 'woocommerce_enable_nocache_headers', false );
 
 		if ( $set_cache ) {
 			$headers['Cache-Control'] = 'no-transform, no-cache, no-store, must-revalidate';

--- a/plugins/woocommerce/includes/class-wc-cache-helper.php
+++ b/plugins/woocommerce/includes/class-wc-cache-helper.php
@@ -52,7 +52,17 @@ class WC_Cache_Helper {
 		$set_cache = (bool) apply_filters( 'woocommerce_enable_nocache_headers', false );
 
 		if ( $set_cache ) {
-			$headers['Cache-Control'] = 'no-transform, no-cache, no-store, must-revalidate';
+			$new_directives = array(
+				'no-transform',
+				'no-cache',
+				'no-store',
+				'must-revalidate',
+			);
+			$old_directives = array();
+			if ( isset( $headers['Cache-Control'] ) ) {
+				$old_directives = preg_split( '/\s*,\s*/', $headers['Cache-Control'] );
+			}
+			$headers['Cache-Control'] = implode( ', ', array_unique( array_merge( $old_directives, $new_directives ) ) );
 		}
 		return $headers;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I found that nocache headers were being sent on the Cart page seemingly unnecessarily. This appears to have been done for the sake of the browser's back/forward cache (bfcache) holding onto a stale cart page which wouldn't reflect a change made from another page after hitting the back button. However, as can be seen in the current version of Chrome, this no longer seems to be the case. (See screen recording below.)

In particular, this is no longer necessary because there is a `pageshow` event listener running on the Cart page to update the cart whenever landing on the cart after a bfcache navigation. For example:

https://github.com/woocommerce/woocommerce/blob/4697b875ed8bf161691deb312ce8e459a07cc319/plugins/woocommerce/client/legacy/js/frontend/cart-fragments.js#L109-L115

This PR therefore improves performance of navigating to and from the cart page by allowing the page to be served from bfcache.

Finally, this PR ensures the original `Cache-Control` directives from `nocache_headers()` are preserved when additional nocache headers are set. Namely, in WP core changeset [r55968](https://core.trac.wordpress.org/changeset/55968) the use of `private` was introduced.

----

This includes a commit (33c6961f54d4e9a4e55150089fc7617cc4eae7fb) from https://github.com/woocommerce/woocommerce/pull/58444 to remove the obsolete Google Web Light support. Once that PR is merged, that change will be removed from this PR.

### Screenshots or screen recordings:

https://github.com/user-attachments/assets/0fc35e38-19fc-463e-a4be-3f6d50be3857

### How to test the changes in this Pull Request:

0. Log out of WordPress (if logged-in, since `Cache-Control: no-store` is currently sent for authenticated users).
1. Add products to the cart.
2. Open DevTools to see the Back/Forward Cache test panel.
3. Click on one of the products in the cart.
4. From the mini-cart in the header, remove the first item in the cart.
5. Click the back button.
6. See that the Cart page was loaded instantly, that the page was loaded from bfcache, and see that the Cart is updated with the product removed.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='/plugin-woocommerce' changelog add` and push it into the branch (replace `/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>