### PR TITLE
TESTING: Show correct heading for billing address when Local Pickup is selected

### DIFF
--- a/plugins/woocommerce/changelog/fix-58213
+++ b/plugins/woocommerce/changelog/fix-58213
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix - Show 'Billing address' instead of 'Billing and shipping address' when Local Pickup is selected and shipping is forced to the billing address.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
@@ -4,7 +4,10 @@
 import clsx from 'clsx';
 import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/blocks-components';
-import { useCheckoutAddress } from '@woocommerce/base-context/hooks';
+import {
+	useCheckoutAddress,
+	useShippingData,
+} from '@woocommerce/base-context/hooks';
 import { useSelect } from '@wordpress/data';
 import { checkoutStore } from '@woocommerce/block-data';
 
@@ -37,14 +40,21 @@ const FrontendBlock = ( {
 	const { showBillingFields, forcedBillingAddress, useBillingAsShipping } =
 		useCheckoutAddress();
 
+	const { hasSelectedLocalPickup } = useShippingData();
+
 	if ( ! showBillingFields && ! useBillingAsShipping ) {
 		return null;
 	}
 
-	title = getBillingAddresssBlockTitle( title, forcedBillingAddress );
+	title = getBillingAddresssBlockTitle(
+		title,
+		forcedBillingAddress,
+		hasSelectedLocalPickup
+	);
 	description = getBillingAddresssBlockDescription(
 		description,
-		forcedBillingAddress
+		forcedBillingAddress,
+		hasSelectedLocalPickup
 	);
 	return (
 		<FormStep

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
@@ -40,7 +40,13 @@ const FrontendBlock = ( {
 	const { showBillingFields, forcedBillingAddress, useBillingAsShipping } =
 		useCheckoutAddress();
 
-	const { hasSelectedLocalPickup } = useShippingData();
+	const { shippingRates } = useShippingData();
+
+	const hasSelectedLocalPickup = shippingRates.some( ( pkg ) =>
+		pkg.shipping_rates.some(
+			( rate ) => rate.method_id === 'pickup_location' && rate.selected
+		)
+	);
 
 	if ( ! showBillingFields && ! useBillingAsShipping ) {
 		return null;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/utils.tsx
@@ -10,10 +10,11 @@ import {
 
 export const getBillingAddresssBlockTitle = (
 	title: string,
-	forcedBillingAddress: boolean
+	forcedBillingAddress: boolean,
+	isLocalPickup: boolean
 ): string => {
-	if ( forcedBillingAddress ) {
-		// Returns default forced billing title when forced billing address is enabled and there is no title set.
+	if ( forcedBillingAddress && ! isLocalPickup ) {
+		// Returns the combined "Billing and shipping address" title only if forced billing is enabled and Local Pickup is not selected, and no custom title is set.
 		return title === DEFAULT_TITLE ? DEFAULT_FORCED_BILLING_TITLE : title;
 	}
 	// Returns default title when forced billing address is disabled and there is no title set.
@@ -22,10 +23,11 @@ export const getBillingAddresssBlockTitle = (
 
 export const getBillingAddresssBlockDescription = (
 	description: string,
-	forcedBillingAddress: boolean
+	forcedBillingAddress: boolean,
+	isLocalPickup: boolean
 ): string => {
-	if ( forcedBillingAddress ) {
-		// Returns default forced billing description when forced billing address is enabled and there is no description set.
+	if ( forcedBillingAddress && ! isLocalPickup ) {
+		// Returns the combined "Billing and shipping address" description if forced billing is enabled, Local Pickup is not selected, and the default description is used.
 		return description === DEFAULT_DESCRIPTION
 			? DEFAULT_FORCED_BILLING_DESCRIPTION
 			: description;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #58213  .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

![Screenshot from 2025-05-23 00-33-43](https://github.com/user-attachments/assets/2b3c1804-40cf-4dfa-bb5b-ce44ce3e1c17)



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### How to test the changes in this Pull Request

1. **Enable Local Pickup**
   - Go to `WooCommerce > Settings > Shipping`.
   - Create a Shipping Zone if one doesn’t exist.
   - Add a **Local Pickup** method to the zone.

2. **Enable "Force shipping to the customer billing address"**
   - Go to `WooCommerce > Settings > Shipping > Shipping destination`.
   - Enable the checkbox: **"Force shipping to the customer billing address"**.
   - Save the settings.

3. **Navigate to Checkout**
   - Add any product to the cart.

4. **Verify heading behavior**
   - Select a shipping method (e.g., **Ship**):
     -  The address heading should read: **"Billing and shipping address"**.
   - Switch to **Local Pickup**:
     -  The heading should update to: **"Billing address"** only.

This ensures the heading accurately reflects the actual checkout scenario.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='/plugin-woocommerce' changelog add` and push it into the branch (replace `/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fix - Show 'Billing address' instead of 'Billing and shipping address' when Local Pickup is selected and shipping is forced to the billing address.
</details>