### PR TITLE
TESTING: [dev] Release: switch release-workflows to run on Blacksmith (batch 1)

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -24,7 +24,7 @@ jobs:
     name: 'Verify if any PR is left open by author:app/github-actions'
     outputs:
       runBuildZipJob: ${{ steps.verify-prs.outputs.runBuildZipJob }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     steps:
         - name: Verify if any PR is left open by author:app/github-actions
           id: verify-prs
@@ -99,7 +99,7 @@ jobs:
 
   verify-release-versions:
     name: 'Verify release and stable tag versions'
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -148,7 +148,7 @@ jobs:
 
   build:
     name: Build release zip file
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     needs: [ verify-prs, verify-release-versions ]
     permissions:
       contents: read
@@ -189,7 +189,7 @@ jobs:
 
   create-release:
     name: Create GitHub release
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     needs: build
     if: ${{ inputs.create_github_release }}
     permissions:

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -24,7 +24,7 @@ jobs:
     name: 'Verify if any PR is left open by author:app/github-actions'
     outputs:
       runBuildZipJob: ${{ steps.verify-prs.outputs.runBuildZipJob }}
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     steps:
         - name: Verify if any PR is left open by author:app/github-actions
           id: verify-prs
@@ -99,7 +99,7 @@ jobs:
 
   verify-release-versions:
     name: 'Verify release and stable tag versions'
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -148,7 +148,7 @@ jobs:
 
   build:
     name: Build release zip file
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-4vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-4vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     needs: [ verify-prs, verify-release-versions ]
     permissions:
       contents: read
@@ -189,7 +189,7 @@ jobs:
 
   create-release:
     name: Create GitHub release
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     needs: build
     if: ${{ inputs.create_github_release }}
     permissions:

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -148,7 +148,7 @@ jobs:
 
   build:
     name: Build release zip file
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-4vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     needs: [ verify-prs, verify-release-versions ]
     permissions:
       contents: read

--- a/.github/workflows/release-cfe-cherry-pick.yml
+++ b/.github/workflows/release-cfe-cherry-pick.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
     verify:
         name: Verify
-        runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+        runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
         permissions:
             contents: read
             pull-requests: read
@@ -75,7 +75,7 @@ jobs:
 
     prep:
         name: Prep inputs
-        runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+        runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
         if: needs.verify.outputs.run == 'true'
         needs: verify
         outputs:
@@ -105,7 +105,7 @@ jobs:
 
     check-release-branch-exists:
         name: Check for existence of release branch
-        runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+        runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
         needs: prep
         steps:
             - name: Check for release branch
@@ -124,7 +124,7 @@ jobs:
 
     cherry-pick-run:
         name: Run cherry pick tool
-        runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+        runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
         permissions:
           actions: write
           contents: write

--- a/.github/workflows/release-cfe-cherry-pick.yml
+++ b/.github/workflows/release-cfe-cherry-pick.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
     verify:
         name: Verify
-        runs-on: ubuntu-latest
+        runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
         permissions:
             contents: read
             pull-requests: read
@@ -75,7 +75,7 @@ jobs:
 
     prep:
         name: Prep inputs
-        runs-on: ubuntu-latest
+        runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
         if: needs.verify.outputs.run == 'true'
         needs: verify
         outputs:
@@ -105,7 +105,7 @@ jobs:
 
     check-release-branch-exists:
         name: Check for existence of release branch
-        runs-on: ubuntu-latest
+        runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
         needs: prep
         steps:
             - name: Check for release branch
@@ -124,7 +124,7 @@ jobs:
 
     cherry-pick-run:
         name: Run cherry pick tool
-        runs-on: ubuntu-latest
+        runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
         permissions:
           actions: write
           contents: write

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   check-feature-freeze-event:
     name: Check for Feature Freeze events today
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     outputs:
       should-run: ${{ steps.check-feature-freeze-event.outputs.should-run }}
     steps:
@@ -65,7 +65,7 @@ jobs:
     name: Calculate versions and confirm repo is in a good state
     needs: check-feature-freeze-event
     if: ${{ needs.check-feature-freeze-event.outputs.should-run == 'true' }}
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     outputs:
       nextReleaseBranch: ${{ steps.calculate-versions.outputs.nextReleaseBranch }}
       nextReleaseVersion: ${{ steps.calculate-versions.outputs.nextReleaseVersion }}
@@ -109,7 +109,7 @@ jobs:
 
   run-code-freeze:
     name: Perform code freeze
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     needs: prepare-for-code-freeze
     permissions:
       contents: write

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   check-feature-freeze-event:
     name: Check for Feature Freeze events today
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     outputs:
       should-run: ${{ steps.check-feature-freeze-event.outputs.should-run }}
     steps:
@@ -65,7 +65,7 @@ jobs:
     name: Calculate versions and confirm repo is in a good state
     needs: check-feature-freeze-event
     if: ${{ needs.check-feature-freeze-event.outputs.should-run == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     outputs:
       nextReleaseBranch: ${{ steps.calculate-versions.outputs.nextReleaseBranch }}
       nextReleaseVersion: ${{ steps.calculate-versions.outputs.nextReleaseVersion }}
@@ -109,7 +109,7 @@ jobs:
 
   run-code-freeze:
     name: Perform code freeze
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     needs: prepare-for-code-freeze
     permissions:
       contents: write

--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build-prep:
     name: Create changelog PR
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build-prep:
     name: Create changelog PR
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-feature-highlights-notification.yml
+++ b/.github/workflows/release-feature-highlights-notification.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-feature-freeze:
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     outputs:
       event-version: ${{ steps.find-feature-freeze-event.outputs.event-version }}
       event-title: ${{ steps.find-feature-freeze-event.outputs.event-title }}
@@ -67,7 +67,7 @@ jobs:
   notify-upcoming-feature-freeze:
     needs: check-feature-freeze
     if: needs.check-feature-freeze.outputs.event-title != ''
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     steps:
       - name: Send feature highlight reminder notification
         uses: archive/github-actions-slack@a62d71a4ea93e68cbdc37581166b0298bea512e9 # v 2.10.0

--- a/.github/workflows/release-feature-highlights-notification.yml
+++ b/.github/workflows/release-feature-highlights-notification.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-feature-freeze:
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     outputs:
       event-version: ${{ steps.find-feature-freeze-event.outputs.event-version }}
       event-title: ${{ steps.find-feature-freeze-event.outputs.event-title }}
@@ -67,7 +67,7 @@ jobs:
   notify-upcoming-feature-freeze:
     needs: check-feature-freeze
     if: needs.check-feature-freeze.outputs.event-title != ''
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     steps:
       - name: Send feature highlight reminder notification
         uses: archive/github-actions-slack@a62d71a4ea93e68cbdc37581166b0298bea512e9 # v 2.10.0

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   notify-release-published:
     name: 'Notify in Slack when a new (pre)release is published'
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     if: ${{ !contains(github.event.release.tag_name, 'wc-beta-tester') }}
 
     steps:
@@ -23,7 +23,7 @@ jobs:
 
   update-global-changelog:
     name: 'Update changelog.txt after any stable release'
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     if: ${{ ! contains( github.event.release.tag_name, 'wc-beta-tester' ) && ! contains( github.event.release.tag_name, '-rc' )  }}
 
     steps:

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   notify-release-published:
     name: 'Notify in Slack when a new (pre)release is published'
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     if: ${{ !contains(github.event.release.tag_name, 'wc-beta-tester') }}
 
     steps:
@@ -23,7 +23,7 @@ jobs:
 
   update-global-changelog:
     name: 'Update changelog.txt after any stable release'
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     if: ${{ ! contains( github.event.release.tag_name, 'wc-beta-tester' ) && ! contains( github.event.release.tag_name, '-rc' )  }}
 
     steps:

--- a/.github/workflows/release-update-stable-tag.yml
+++ b/.github/workflows/release-update-stable-tag.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   validate-release:
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     outputs:
       version: ${{ steps.extract-version.outputs.version }}
       branch: ${{ steps.extract-version.outputs.branch }}
@@ -135,7 +135,7 @@ jobs:
           fi
 
   update-wporg-stable-tag:
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     needs: validate-release
     steps:
       - name: Install SVN
@@ -170,7 +170,7 @@ jobs:
           fi
 
   update-gh-stable-tag:
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     needs: [validate-release, update-wporg-stable-tag]
     strategy:
       matrix:
@@ -233,7 +233,7 @@ jobs:
           fi
 
   notify-release:
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     needs: [validate-release, update-wporg-stable-tag, update-gh-stable-tag]
     if: ${{ github.event.inputs.allow-revert != 'true' }}
     steps:

--- a/.github/workflows/release-update-stable-tag.yml
+++ b/.github/workflows/release-update-stable-tag.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   validate-release:
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     outputs:
       version: ${{ steps.extract-version.outputs.version }}
       branch: ${{ steps.extract-version.outputs.branch }}
@@ -135,7 +135,7 @@ jobs:
           fi
 
   update-wporg-stable-tag:
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     needs: validate-release
     steps:
       - name: Install SVN
@@ -170,7 +170,7 @@ jobs:
           fi
 
   update-gh-stable-tag:
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     needs: [validate-release, update-wporg-stable-tag]
     strategy:
       matrix:
@@ -233,7 +233,7 @@ jobs:
           fi
 
   notify-release:
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     needs: [validate-release, update-wporg-stable-tag, update-gh-stable-tag]
     if: ${{ github.event.inputs.allow-revert != 'true' }}
     steps:

--- a/.github/workflows/release-upload-to-wporg.yml
+++ b/.github/workflows/release-upload-to-wporg.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   get-and-validate-release-asset:
     name: Get intended release details
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     permissions:
       contents: write # Required to fetch draft releases for some reason. See https://github.com/cli/cli/issues/9076#issuecomment-2146148572.
     outputs:
@@ -125,7 +125,7 @@ jobs:
 
   commit:
     name: Commit release to WordPress.org
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     needs: [get-and-validate-release-asset]
     permissions:
       contents: write # Required to fetch draft releases for some reason. See https://github.com/cli/cli/issues/9076#issuecomment-2146148572.

--- a/.github/workflows/release-upload-to-wporg.yml
+++ b/.github/workflows/release-upload-to-wporg.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   get-and-validate-release-asset:
     name: Get intended release details
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     permissions:
       contents: write # Required to fetch draft releases for some reason. See https://github.com/cli/cli/issues/9076#issuecomment-2146148572.
     outputs:
@@ -125,7 +125,7 @@ jobs:
 
   commit:
     name: Commit release to WordPress.org
-    runs-on: ubuntu-latest
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2204' ) || 'ubuntu-latest' }}
     needs: [get-and-validate-release-asset]
     permissions:
       contents: write # Required to fetch draft releases for some reason. See https://github.com/cli/cli/issues/9076#issuecomment-2146148572.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #58171, WOOPLUG-4353

Migrates the first batch of the release workflows to run on Blacksmith.

### How to test the changes in this Pull Request:

- CI-checks shall pass
- Inspect the example runs: [one](https://github.com/woocommerce/woocommerce/actions/runs/16026040208), [two](https://github.com/woocommerce/woocommerce/actions/runs/16025930388)
